### PR TITLE
Fix gulp instructions

### DIFF
--- a/source/_docs/getting-started.md
+++ b/source/_docs/getting-started.md
@@ -89,54 +89,56 @@ The same demo as above, just with Latte syntax.
 
 It is quite annoying to refresh regenerate content manually every time you change the code.
 
-Simple Gulp script can regenerate content for use.
+A simple Gulp script can regenerate content for use.
 
-Install `gulp` and `gulp-watch`:
+1. Install `gulp` and `gulp-watch`:
 
-```bash
-npm install -g gulp gulp-watch
-```
+  ```bash
+  npm install -g gulp gulp-watch
+  ```
 
-```javascript
-var gulp = require("gulp");
-var watch = require("gulp-watch");
-var exec = require("child_process").exec;
+2. Then create `gulpfile.js`:
 
-gulp.task("default", function() {
-	// Run local server, open localhost:8000 in your browser
-	exec("php -S localhost:8000 -t output");
+  ```javascript
+  var gulp = require("gulp");
+  var watch = require("gulp-watch");
+  var exec = require("child_process").exec;
+  
+  gulp.task("default", function() {
+  	// Run local server, open localhost:8000 in your browser
+  	exec("php -S localhost:8000 -t output");
+  
+  	// Generate current version
+  	// For Windows use: exec('vendor\\bin\\statie generate', function (err, stdout, stderr) {
+  	exec("vendor/bin/statie generate source", function(err, stdout, stderr) {
+  		console.log(stdout);
+  		console.log(stderr);
+  	});
+  
+  	return (
+  		watch(["source/**/*", "!**/*___jb_tmp___"], { ignoreInitial: false })
+  			// For the second arg see: https://github.com/floatdrop/gulp-watch/issues/242#issuecomment-230209702
+  			.on("change", function() {
+  				// For Windows use: exec('vendor\\bin\\statie generate', function (err, stdout, stderr) {
+  				exec("vendor/bin/statie generate source", function(
+  					err,
+  					stdout,
+  					stderr
+  				) {
+  					console.log(stdout);
+  					console.log(stderr);
+  				});
+  			})
+  	);
+  });
+  ```
 
-	// Generate current version
-	// For Windows use: exec('vendor\\bin\\statie generate', function (err, stdout, stderr) {
-	exec("vendor/bin/statie generate", function(err, stdout, stderr) {
-		console.log(stdout);
-		console.log(stderr);
-	});
+3. Run the script via:
 
-	return (
-		watch(["source/**/*", "!**/*___jb_tmp___"], { ignoreInitial: false })
-			// For the second arg see: https://github.com/floatdrop/gulp-watch/issues/242#issuecomment-230209702
-			.on("change", function() {
-				// For Windows use: exec('vendor\\bin\\statie generate', function (err, stdout, stderr) {
-				exec("vendor/bin/statie generate", function(
-					err,
-					stdout,
-					stderr
-				) {
-					console.log(stdout);
-					console.log(stderr);
-				});
-			})
-	);
-});
-```
+  ```bash
+  gulp
+  ```
 
-And run the script via:
-
-```bash
-gulp
-```
-
-Now open [localhost:8000](http://localhost:8000) and change `source/index.twig`.
+4. Now open [localhost:8000](http://localhost:8000) and change `source/index.twig`.
 
 It works!


### PR DESCRIPTION
Closes #36 

## Changes
1. Clarify the filename to put the gulp script in.
2. Add  to statie commands in gruntfile.js.
3. Adds numbered list to Gulp steps.